### PR TITLE
Change Trealtype from Single to Double. 

### DIFF
--- a/Sources/CS4BaseTypes.pas
+++ b/Sources/CS4BaseTypes.pas
@@ -23,7 +23,8 @@ type
    <B=Note>: I don't think that this type will change due to storage
    and speed efficency.
 }
-  TRealType = Single;
+ // TRealType = Single;
+  TRealType = Double;
 {: This type is the result information of a clipping method. The
    clipping functions are used internally by the library and you
    don't need to use them directly.


### PR DESCRIPTION
 This fixes the display error when coordinates are more than 2million. This makes wrong display as trace works in snap of 0.25 or 0.50 . this makes wrong shapes on ellipse.
